### PR TITLE
Use online Protomaps tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-Change images in "pictures"
-updates infos in "locations.json"
+This version loads map tiles directly from the Protomaps online service.
+Simply host the project on any static web server and open `index.html` in a browser.
+If you want to change the pictures, update the files in `img` and adjust `locations.json` accordingly.

--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
         <title>MSF GUESSR</title>
         <link rel='stylesheet' href='css/bootstrap.css' />
         <link rel='stylesheet' href='css/style.css' />
-        <link rel="stylesheet" href="offline_assets/leaflet/leaflet.css" />
-	<script src="offline_assets/leaflet/leaflet.js"></script>	
-	<script src="offline_assets/protomaps-leaflet.js"></script>
-        <script type='text/javascript' src='offline_assets/jquery-3.7.1.min.js'></script>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@1.0.0"></script>
+        <script type='text/javascript' src='https://code.jquery.com/jquery-3.7.1.min.js'></script>
         <script type='text/javascript' src='js/rnd.js'></script>
         <script type='text/javascript' src='js/minimap.js'></script>
         <script type='text/javascript' src='js/roundmap.js'></script>

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -3,7 +3,7 @@ function mminitialize() {
 
     // Add your Protomaps PMTiles vector layer
     protomapsL.leafletLayer({
-        url: 'offline_assets/planet_z8.pmtiles',
+        url: 'https://tiles.protomaps.com/tiles/v3/{z}/{x}/{y}.pbf',
         flavor: "light",
         lang: "fr",
         attribution: "© OpenStreetMap, © Protomaps"

--- a/js/roundmap.js
+++ b/js/roundmap.js
@@ -2,7 +2,7 @@ function rminitialize() {
     roundmap = L.map("roundMap").setView([30, 8], 1);
 
     protomapsL.leafletLayer({
-        url: 'offline_assets/planet_z8.pmtiles',
+        url: 'https://tiles.protomaps.com/tiles/v3/{z}/{x}/{y}.pbf',
         flavor: "light",
         lang: "fr",
         attribution: "© OpenStreetMap, © Protomaps"


### PR DESCRIPTION
## Summary
- switch Protomaps layers to online tiles
- load Leaflet, Protomaps and jQuery from public CDNs
- update README for online usage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68758c3c9704832390edda95a6972056