### PR TITLE
Fix PMTiles script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
     <!-- PMTiles support for raster -->
     <!-- Load the PMTiles library (UMD build) -->
-    <script src="https://cdn.jsdelivr.net/npm/pmtiles@3.0.0-beta.7/dist/pmtiles.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pmtiles@3.0.0-beta.7/dist/pmtiles.umd.js"></script>
     <script>
         const { PMTiles, leafletRasterLayer } = pmtiles;
     </script>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
     <!-- PMTiles support for raster -->
-    <script src="https://cdn.jsdelivr.net/npm/pmtiles@3.0.0-beta.7/dist/pmtiles.umd.js"></script>
+    <!-- Load the PMTiles library (UMD build) -->
+    <script src="https://cdn.jsdelivr.net/npm/pmtiles@3.0.0-beta.7/dist/pmtiles.js"></script>
     <script>
         const { PMTiles, leafletRasterLayer } = pmtiles;
     </script>

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -1,4 +1,4 @@
-unction mminitialize() {
+function mminitialize() {
     mymap = L.map("miniMap");
     mymap.setView([30, 10], 1);
 


### PR DESCRIPTION
## Summary
- fix broken `mminitialize` function
- correct PMTiles CDN path for map loading

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687788692200832393c95329db5b2f3f